### PR TITLE
CI安定化: west.yml の外部モジュール3件をSHA固定（ZMK v0.3.0）

### DIFF
--- a/boards/shields/mona2/mona2_r.overlay
+++ b/boards/shields/mona2/mona2_r.overlay
@@ -52,7 +52,7 @@
         reg = <0>;
         spi-max-frequency = <2000000>;
         irq-gpios = <&gpio0 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; //P0.02を指定(MOTION)
-        cpi = <600>;
+        cpi = <1200>;
         //swap-xy;
         invert-x; //COROPIT版ではコメントアウトを外す
         invert-y; //COROPIT版ではコメントアウトを外す

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -273,10 +273,10 @@
 
         symbol {
             bindings = <
-&kp EXCLAMATION  &kp CARET   &kp TILDE  &kp SEMICOLON  &kp COLON                                &kp SINGLE_QUOTE   &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LESS_THAN  &kp GREATER_THAN
-&kp AMPERSAND    &kp DOLLAR  &kp HASH   &kp AT_SIGN    &kp UNDERSCORE            &kp BACKSLASH  &kp DOUBLE_QUOTES  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp A          &kp A
-&kp A            &kp A       &kp A      &kp A          &kp A           &trans    &kp PIPE       &kp GRAVE          &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp A          &kp A
-&trans           &trans      &trans     &trans         &trans          &trans    &trans         &trans                                                                         &trans
+&kp PERCENT    &kp EXCLAMATION  &kp QUESTION  &kp SEMICOLON  &kp COLON                         &kp SINGLE_QUOTE   &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LESS_THAN  &kp GREATER_THAN
+&kp AMPERSAND  &kp DOLLAR       &kp HASH      &kp AT_SIGN    &kp UNDERSCORE            &trans  &kp DOUBLE_QUOTES  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp TILDE      &kp BACKSLASH
+&kp EQUAL      &kp PLUS         &kp MINUS     &kp ASTERISK   &kp SLASH       &trans    &trans  &kp GRAVE          &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp CARET      &kp PIPE
+&trans         &trans           &trans        &trans         &trans          &trans    &trans  &trans                                                                         &trans
             >;
 
             sensor-bindings = <&inc_dec_kp LEFT RIGHT>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -308,7 +308,7 @@
             bindings = <
 &none      &none      &kp LG(LS(N3))  &kp LG(LS(N4))  &kp LG(PLUS)                                     &none          &none  &none  &none  &kp LG(P)
 &kp LG(A)  &kp LG(S)  &none           &kp LG(F)       &kp LG(MINUS)                 &kp LG(LC(V))      &none          &none  &none  &none  &none
-&kp LG(Z)  &kp LG(X)  &kp LG(C)       &kp LG(V)       &kp LG(B)      &none          &none              &none          &none  &none  &none  &none
+&kp LG(Z)  &kp LG(X)  &kp LG(C)       &kp LG(V)       &kp LG(SLASH)  &none          &none              &none          &none  &none  &none  &none
 &none      &none      &none           &mbt1_command   &kp LG(SPACE)  &kp LG(TAB)    &kp LG(BACKSPACE)  &kp LG(ENTER)                       &kp LC(DOWN)
             >;
 

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -241,7 +241,7 @@
         flow: flow {
             compatible = "zmk,behavior-hold-tap";
             label = "FLOW";
-            bindings = <&kp>, <&flow_hold>;
+            bindings = <&kp>, <&kp>;
 
             #binding-cells = <2>;
             tapping-term-ms = <170>;
@@ -253,10 +253,10 @@
 
         default_layer {
             bindings = <
-&kp Q      &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                         &kp F                      &kp W  &kp R  &kp Y  &kp P
-&kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &mt LG(LA(LC(K))) LG(LA(LC(L)))  &kp K                      &kp T  &kp N  &kp S  &kp H
-&kp X      &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1                 &kp G                      &kp D  &kp M  &kp Z  &kp B
-&lt 8 ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE          &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
+&kp Q      &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                           &kp F                      &kp W  &kp R  &kp Y  &kp P
+&kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &flow LG(LA(LC(K))) LG(LA(LC(L)))  &kp K                      &kp T  &kp N  &kp S  &kp H
+&kp X      &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1                   &kp G                      &kp D  &kp M  &kp Z  &kp B
+&lt 8 ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE            &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -254,7 +254,7 @@
         default_layer {
             bindings = <
 &kp Q      &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                 &kp F                      &kp W  &kp R  &kp Y  &kp P
-&kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &flow RG(GLOBE) GLOBE    &kp K                      &kp T  &kp N  &kp S  &kp H
+&kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &flow GLOBE RG(GLOBE)    &kp K                      &kp T  &kp N  &kp S  &kp H
 &kp X      &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1         &kp G                      &kp D  &kp M  &kp Z  &kp B
 &lt 8 ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE  &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
             >;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -295,10 +295,10 @@
 
         number {
             bindings = <
-&trans  &trans  &trans  &trans  &trans                    &comma           &kp KP_NUMBER_7  &kp KP_NUMBER_8  &kp KP_NUMBER_9  &trans
-&trans  &trans  &trans  &trans  &trans            &trans  &kp KP_DOT       &kp KP_NUMBER_4  &kp KP_NUMBER_5  &kp KP_NUMBER_6  &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &kp KP_NUMBER_0  &kp KP_NUMBER_1  &kp KP_NUMBER_2  &kp KP_NUMBER_3  &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans                                                              &trans
+&trans       &trans        &trans           &trans        &trans                          &comma           &kp KP_NUMBER_7  &kp KP_NUMBER_8  &kp KP_NUMBER_9  &trans
+&kp KP_PLUS  &kp KP_MINUS  &kp KP_ASTERISK  &kp KP_SLASH  &kp KP_EQUAL            &trans  &kp KP_DOT       &kp KP_NUMBER_4  &kp KP_NUMBER_5  &kp KP_NUMBER_6  &trans
+&trans       &trans        &trans           &trans        &trans        &trans    &trans  &kp KP_NUMBER_0  &kp KP_NUMBER_1  &kp KP_NUMBER_2  &kp KP_NUMBER_3  &trans
+&trans       &trans        &trans           &trans        &trans        &trans    &trans  &trans                                                              &trans
             >;
 
             sensor-bindings = <&inc_dec_kp LEFT RIGHT>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -254,7 +254,7 @@
         default_layer {
             bindings = <
 &kp Q                 &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                 &kp F                      &kp W  &kp R  &kp Y  &kp P
-&kp U                 &kp I         &kp A          &kp O      &kp MINUS                                         &flow GLOBE RG(GLOBE)    &kp K                      &kp T  &kp N  &kp S  &kp H
+&kp A                 &kp I         &kp U          &kp O      &kp MINUS                                         &flow GLOBE RG(GLOBE)    &kp K                      &kp T  &kp N  &kp S  &kp H
 &kp X                 &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1         &kp G                      &kp D  &kp M  &kp Z  &kp B
 &mt LEFT_CONTROL ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE  &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
             >;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -273,10 +273,10 @@
 
         symbol {
             bindings = <
-&kp EXCLAMATION  &kp CARET      &kp TILDE      &kp LESS_THAN  &kp GREATER_THAN                           &kp SINGLE_QUOTE   &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp ASTERISK  &kp SLASH
-&kp PERCENT      &kp AMPERSAND  &kp HASH       &kp AT_SIGN    &kp UNDERSCORE              &kp BACKSLASH  &kp DOUBLE_QUOTES  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp PLUS      &kp MINUS
-&kp LA(Y)        &kp DOLLAR     &kp SEMICOLON  &kp COLON      &kp QUESTION      &trans    &kp PIPE       &kp GRAVE          &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp EQUAL     &kp COMMA
-&trans           &trans         &trans         &trans         &trans            &trans    &trans         &trans                                                                        &trans
+&kp EXCLAMATION  &kp CARET   &kp TILDE  &kp SEMICOLON  &kp COLON                                &kp SINGLE_QUOTE   &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LESS_THAN  &kp GREATER_THAN
+&kp AMPERSAND    &kp DOLLAR  &kp HASH   &kp AT_SIGN    &kp UNDERSCORE            &kp BACKSLASH  &kp DOUBLE_QUOTES  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp A          &kp A
+&kp A            &kp A       &kp A      &kp A          &kp A           &trans    &kp PIPE       &kp GRAVE          &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp A          &kp A
+&trans           &trans      &trans     &trans         &trans          &trans    &trans         &trans                                                                         &trans
             >;
 
             sensor-bindings = <&inc_dec_kp LEFT RIGHT>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -253,7 +253,7 @@
 
         default_layer {
             bindings = <
-&kp A      &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                 &kp F                      &kp W  &kp R  &kp Y  &kp P
+&kp Q      &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                 &kp F                      &kp W  &kp R  &kp Y  &kp P
 &kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &flow GLOBE A            &kp K                      &kp T  &kp N  &kp S  &kp H
 &kp X      &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1         &kp G                      &kp D  &kp M  &kp Z  &kp B
 &lt 8 ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE  &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -42,7 +42,7 @@
         };
 
         connect_mode {
-            bindings = <&mo 9>;
+            bindings = <&mo 8>;
             key-positions = <15 27>;
             layers = <0 1>;
         };
@@ -295,10 +295,10 @@
 
         number {
             bindings = <
-&trans  &trans  &trans  &trans  &trans                             &kp KP_NUMBER_7  &kp KP_NUMBER_8  &kp KP_NUMBER_9  &kp KP_ASTERISK  &kp KP_SLASH
-&trans  &trans  &trans  &trans  &trans            &kp KP_DOT       &kp KP_NUMBER_4  &kp KP_NUMBER_5  &kp KP_NUMBER_6  &kp KP_PLUS      &kp KP_MINUS
-&trans  &trans  &trans  &trans  &trans  &trans    &kp KP_NUMBER_0  &kp KP_NUMBER_1  &kp KP_NUMBER_2  &kp KP_NUMBER_3  &kp KP_EQUAL     &comma
-&trans  &trans  &trans  &trans  &trans  &trans    &trans           &trans                                                              &trans
+&trans  &trans  &trans  &trans  &trans                    &comma           &kp KP_NUMBER_7  &kp KP_NUMBER_8  &kp KP_NUMBER_9  &trans
+&trans  &trans  &trans  &trans  &trans            &trans  &kp KP_DOT       &kp KP_NUMBER_4  &kp KP_NUMBER_5  &kp KP_NUMBER_6  &trans
+&trans  &trans  &trans  &trans  &trans  &trans    &trans  &kp KP_NUMBER_0  &kp KP_NUMBER_1  &kp KP_NUMBER_2  &kp KP_NUMBER_3  &trans
+&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans                                                              &trans
             >;
 
             sensor-bindings = <&inc_dec_kp LEFT RIGHT>;
@@ -328,22 +328,13 @@
 
         cursor {
             bindings = <
-&trans     &trans  &trans            &trans  &trans                    &kp PAGE_UP    &trans          &kp UP_ARROW    &trans           &kp HOME
-&trans     &trans  &trans            &trans  &trans            &trans  &kp PAGE_DOWN  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &kp END
-&trans     &trans  &trans            &trans  &trans  &trans    &trans  &trans         &trans          &trans          &trans           &trans
-&kp LCTRL  &trans  &kp LEFT_COMMAND  &trans  &trans  &trans    &trans  &trans                                                          &trans
+&none      &none   &none             &none  &none                  &kp PAGE_UP    &none           &kp UP_ARROW    &none            &kp HOME
+&none      &none   &none             &none  &none           &none  &kp PAGE_DOWN  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &kp END
+&none      &none   &none             &none  &none  &none    &none  &none          &none           &none           &none            &none
+&kp LCTRL  &trans  &kp LEFT_COMMAND  &none  &none  &none    &none  &none                                                           &none
             >;
 
             sensor-bindings = <&scroll_up_down>;
-        };
-
-        control {
-            bindings = <
-&kp LC(Q)  &kp LC(W)         &kp LC(E)     &kp LC(R)  &kp LC(T)                                   &kp LC(Y)      &kp LC(U)  &kp LC(I)      &kp LC(O)    &kp LC(P)
-&kp LC(A)  &kp LC(S)         &kp LC(D)     &kp LC(F)  &kp LC(G)                     &trans        &kp LC(H)      &kp LC(J)  &kp LC(K)      &kp LC(L)    &kp LC(MINUS)
-&kp LC(Z)  &kp LC(X)         &kp LC(C)     &kp LC(V)  &kp LC(B)      &trans         &trans        &kp LC(N)      &kp LC(M)  &kp LC(COMMA)  &kp LC(DOT)  &kp LC(FSLH)
-&trans     &kp LC(LEFT_ALT)  &kp LC(LGUI)  &trans     &kp LC(SPACE)  &kp LC(TAB)    &kp LC(BSPC)  &kp LC(ENTER)                                         &trans
-            >;
         };
 
         connect {

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -253,10 +253,10 @@
 
         default_layer {
             bindings = <
-&kp Q      &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                 &kp F                      &kp W  &kp R  &kp Y  &kp P
-&kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &mt LG(LA(T)) LG(LA(R))  &kp K                      &kp T  &kp N  &kp S  &kp H
-&kp X      &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1         &kp G                      &kp D  &kp M  &kp Z  &kp B
-&lt 8 ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE  &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
+&kp Q      &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                         &kp F                      &kp W  &kp R  &kp Y  &kp P
+&kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &mt LG(LA(LC(K))) LG(LA(LC(L)))  &kp K                      &kp T  &kp N  &kp S  &kp H
+&kp X      &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1                 &kp G                      &kp D  &kp M  &kp Z  &kp B
+&lt 8 ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE          &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -320,7 +320,7 @@
 &none             &none      &none             &none      &none                  &none  &none     &none     &none     &none
 &none             &none      &none             &none      &none           &none  &none  &none     &none     &none     &none
 &none             &kp LG(X)  &kp LG(C)         &kp LG(V)  &none  &none    &none  &none  &mkp MB1  &mkp MB2  &mkp MB3  &mo 3
-&kp LEFT_CONTROL  &none      &kp LEFT_COMMAND  &none      &none  &none    &none  &none                                &none
+&kp LEFT_CONTROL  &none      &kp LEFT_COMMAND  &mkp MB3   &none  &none    &none  &none                                &none
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -312,7 +312,7 @@
 &none      &none      &none           &mbt1_command   &kp LG(SPACE)  &kp LG(TAB)    &kp LG(BACKSPACE)  &kp LG(ENTER)                       &kp LC(DOWN)
             >;
 
-            sensor-bindings = <&inc_dec_kp LG(PLUS) LG(MINUS)>;
+            sensor-bindings = <&scroll_right_left>;
         };
 
         mouse {

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -317,10 +317,10 @@
 
         mouse {
             bindings = <
-&none             &none      &none             &none      &none                  &none  &none     &none     &none     &none
-&none             &none      &none             &none      &none           &none  &none  &none     &none     &none     &none
-&none             &kp LG(X)  &kp LG(C)         &kp LG(V)  &none  &none    &none  &none  &mkp MB1  &mkp MB2  &mkp MB3  &mo 3
-&kp LEFT_CONTROL  &none      &kp LEFT_COMMAND  &mkp MB3   &none  &none    &none  &none                                &none
+&none             &none         &none             &none      &none                           &none  &none     &none     &none     &none
+&none             &none         &none             &none      &none                    &none  &none  &none     &none     &none     &none
+&none             &kp LG(X)     &kp LG(C)         &kp LG(V)  &none           &none    &none  &none  &mkp MB1  &mkp MB2  &mkp MB3  &mo 3
+&kp LEFT_CONTROL  &kp LEFT_ALT  &kp LEFT_COMMAND  &mkp MB3   &kp LEFT_SHIFT  &none    &none  &none                                &none
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -253,10 +253,10 @@
 
         default_layer {
             bindings = <
-&kp Q      &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                 &kp F                      &kp W  &kp R  &kp Y  &kp P
-&kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &flow GLOBE RG(GLOBE)    &kp K                      &kp T  &kp N  &kp S  &kp H
-&kp X      &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1         &kp G                      &kp D  &kp M  &kp Z  &kp B
-&lt 8 ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE  &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
+&kp Q                 &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                 &kp F                      &kp W  &kp R  &kp Y  &kp P
+&kp A                 &kp I         &kp U          &kp O      &kp MINUS                                         &flow GLOBE RG(GLOBE)    &kp K                      &kp T  &kp N  &kp S  &kp H
+&kp X                 &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1         &kp G                      &kp D  &kp M  &kp Z  &kp B
+&mt LEFT_CONTROL ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE  &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
             >;
 
             sensor-bindings = <&scroll_up_down>;
@@ -306,10 +306,10 @@
 
         shortcut {
             bindings = <
-&none      &none      &kp LG(LS(N3))  &kp LG(LS(N4))  &kp LG(PLUS)                                     &none          &none  &none  &none  &none
+&none      &none      &kp LG(LS(N3))  &kp LG(LS(N4))  &kp LG(PLUS)                                     &none          &none  &none  &none  &kp LG(P)
 &kp LG(A)  &kp LG(S)  &none           &kp LG(F)       &kp LG(MINUS)                 &kp LG(LC(V))      &none          &none  &none  &none  &none
 &kp LG(Z)  &kp LG(X)  &kp LG(C)       &kp LG(V)       &kp LG(B)      &none          &none              &none          &none  &none  &none  &none
-&none      &none      &none           &mkp MB3        &kp LG(SPACE)  &kp LG(TAB)    &kp LG(BACKSPACE)  &kp LG(ENTER)                       &kp LC(DOWN)
+&none      &none      &none           &mbt1_command   &kp LG(SPACE)  &kp LG(TAB)    &kp LG(BACKSPACE)  &kp LG(ENTER)                       &kp LC(DOWN)
             >;
 
             sensor-bindings = <&inc_dec_kp LG(PLUS) LG(MINUS)>;
@@ -339,7 +339,7 @@
 
         control {
             bindings = <
-&kp LC(Q)  &kp LC(W)         &kp LC(E)     &kp LC(R)  &kp LC(A)                                   &kp LC(Y)      &kp LC(U)  &kp LC(I)      &kp LC(O)    &kp LC(P)
+&kp LC(Q)  &kp LC(W)         &kp LC(E)     &kp LC(R)  &kp LC(T)                                   &kp LC(Y)      &kp LC(U)  &kp LC(I)      &kp LC(O)    &kp LC(P)
 &kp LC(A)  &kp LC(S)         &kp LC(D)     &kp LC(F)  &kp LC(G)                     &trans        &kp LC(H)      &kp LC(J)  &kp LC(K)      &kp LC(L)    &kp LC(MINUS)
 &kp LC(Z)  &kp LC(X)         &kp LC(C)     &kp LC(V)  &kp LC(B)      &trans         &trans        &kp LC(N)      &kp LC(M)  &kp LC(COMMA)  &kp LC(DOT)  &kp LC(FSLH)
 &trans     &kp LC(LEFT_ALT)  &kp LC(LGUI)  &trans     &kp LC(SPACE)  &kp LC(TAB)    &kp LC(BSPC)  &kp LC(ENTER)                                         &trans

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -254,7 +254,7 @@
         default_layer {
             bindings = <
 &kp Q      &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                 &kp F                      &kp W  &kp R  &kp Y  &kp P
-&kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &flow GLOBE A            &kp K                      &kp T  &kp N  &kp S  &kp H
+&kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &mt LG(LA(T)) LG(LA(R))  &kp K                      &kp T  &kp N  &kp S  &kp H
 &kp X      &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1         &kp G                      &kp D  &kp M  &kp Z  &kp B
 &lt 8 ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE  &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
             >;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -254,7 +254,7 @@
         default_layer {
             bindings = <
 &kp Q                 &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                 &kp F                      &kp W  &kp R  &kp Y  &kp P
-&kp A                 &kp I         &kp U          &kp O      &kp MINUS                                         &flow GLOBE RG(GLOBE)    &kp K                      &kp T  &kp N  &kp S  &kp H
+&kp U                 &kp I         &kp A          &kp O      &kp MINUS                                         &flow GLOBE RG(GLOBE)    &kp K                      &kp T  &kp N  &kp S  &kp H
 &kp X                 &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1         &kp G                      &kp D  &kp M  &kp Z  &kp B
 &mt LEFT_CONTROL ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE  &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
             >;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -295,10 +295,10 @@
 
         number {
             bindings = <
-&trans       &trans        &trans           &trans        &trans                          &comma           &kp KP_NUMBER_7  &kp KP_NUMBER_8  &kp KP_NUMBER_9  &trans
-&kp KP_PLUS  &kp KP_MINUS  &kp KP_ASTERISK  &kp KP_SLASH  &kp KP_EQUAL            &trans  &kp KP_DOT       &kp KP_NUMBER_4  &kp KP_NUMBER_5  &kp KP_NUMBER_6  &trans
-&trans       &trans        &trans           &trans        &trans        &trans    &trans  &kp KP_NUMBER_0  &kp KP_NUMBER_1  &kp KP_NUMBER_2  &kp KP_NUMBER_3  &trans
-&trans       &trans        &trans           &trans        &trans        &trans    &trans  &trans                                                              &trans
+&trans        &trans       &trans        &trans           &trans                          &comma           &kp KP_NUMBER_7  &kp KP_NUMBER_8  &kp KP_NUMBER_9  &trans
+&trans        &trans       &trans        &trans           &trans                  &trans  &kp KP_DOT       &kp KP_NUMBER_4  &kp KP_NUMBER_5  &kp KP_NUMBER_6  &trans
+&kp KP_EQUAL  &kp KP_PLUS  &kp KP_MINUS  &kp KP_ASTERISK  &kp KP_SLASH  &trans    &trans  &kp KP_NUMBER_0  &kp KP_NUMBER_1  &kp KP_NUMBER_2  &kp KP_NUMBER_3  &trans
+&trans        &trans       &trans        &trans           &trans        &trans    &trans  &trans                                                              &trans
             >;
 
             sensor-bindings = <&inc_dec_kp LEFT RIGHT>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -241,7 +241,7 @@
         flow: flow {
             compatible = "zmk,behavior-hold-tap";
             label = "FLOW";
-            bindings = <&kp>, <&kp>;
+            bindings = <&kp>, <&flow_hold>;
 
             #binding-cells = <2>;
             tapping-term-ms = <170>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -317,10 +317,10 @@
 
         mouse {
             bindings = <
-&none             &none         &none             &none      &none                           &none  &none     &none     &none     &none
-&none             &none         &none             &none      &none                    &none  &none  &none     &none     &none     &none
-&none             &kp LG(X)     &kp LG(C)         &kp LG(V)  &none           &none    &none  &none  &mkp MB1  &mkp MB2  &mkp MB3  &mo 3
-&kp LEFT_CONTROL  &kp LEFT_ALT  &kp LEFT_COMMAND  &mkp MB3   &kp LEFT_SHIFT  &none    &none  &none                                &none
+&kp LC(NUMBER_1)  &kp LC(NUMBER_2)  &kp LC(N3)        &kp LC(NUMBER_4)  &kp LC(NUMBER_5)                  &none  &none         &kp LC(UP)    &none          &none
+&kp LC(NUMBER_6)  &kp LC(NUMBER_7)  &kp LC(NUMBER_8)  &kp LC(NUMBER_9)  &kp LC(NUMBER_0)           &none  &none  &kp LC(LEFT)  &kp LC(DOWN)  &kp LC(RIGHT)  &none
+&none             &kp LG(X)         &kp LG(C)         &kp LG(V)         &none             &none    &none  &none  &mkp MB1      &mkp MB2      &mkp MB3       &mo 3
+&kp LEFT_CONTROL  &kp LEFT_ALT      &kp LEFT_COMMAND  &mkp MB3          &kp LEFT_SHIFT    &none    &none  &none                                             &none
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -253,10 +253,10 @@
 
         default_layer {
             bindings = <
-&kp Q      &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                           &kp F                      &kp W  &kp R  &kp Y  &kp P
-&kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &flow LG(LA(LC(K))) LG(LA(LC(L)))  &kp K                      &kp T  &kp N  &kp S  &kp H
-&kp X      &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1                   &kp G                      &kp D  &kp M  &kp Z  &kp B
-&lt 8 ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE            &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
+&kp Q      &kp L         &kp E          &kp COMMA  &kp PERIOD                                                                 &kp F                      &kp W  &kp R  &kp Y  &kp P
+&kp A      &kp I         &kp U          &kp O      &kp MINUS                                         &flow RG(GLOBE) GLOBE    &kp K                      &kp T  &kp N  &kp S  &kp H
+&kp X      &kp J         &kp C          &kp V      &kp SLASH             &kp_num_sym 0 LANGUAGE_2    &lt 2 LANGUAGE_1         &kp G                      &kp D  &kp M  &kp Z  &kp B
+&lt 8 ESC  &kp LEFT_ALT  &mo_mkp 5 MB2  &mkp MB1   &mt LEFT_SHIFT SPACE  &lt 2 TAB                   &kp_num_sym 0 BACKSPACE  &kp_cursor_scroll 0 ENTER                       &lt 6 LC(UP)
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -308,19 +308,19 @@
             bindings = <
 &none      &none      &kp LG(LS(N3))  &kp LG(LS(N4))  &kp LG(PLUS)                                     &none          &none  &none  &none  &none
 &kp LG(A)  &kp LG(S)  &none           &kp LG(F)       &kp LG(MINUS)                 &kp LG(LC(V))      &none          &none  &none  &none  &none
-&kp LG(Z)  &kp LG(X)  &kp LG(C)       &kp LG(V)       &kp LG(B)      &mo 10         &none              &none          &none  &none  &none  &none
-&none      &none      &none           &mbt1_command   &kp LG(SPACE)  &kp LG(TAB)    &kp LG(BACKSPACE)  &kp LG(ENTER)                       &kp LC(DOWN)
+&kp LG(Z)  &kp LG(X)  &kp LG(C)       &kp LG(V)       &kp LG(B)      &none          &none              &none          &none  &none  &none  &none
+&none      &none      &none           &mkp MB3        &kp LG(SPACE)  &kp LG(TAB)    &kp LG(BACKSPACE)  &kp LG(ENTER)                       &kp LC(DOWN)
             >;
 
-            sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN>;
+            sensor-bindings = <&inc_dec_kp LG(PLUS) LG(MINUS)>;
         };
 
         mouse {
             bindings = <
-&trans            &trans     &trans            &trans     &trans                    &trans  &trans    &trans    &trans    &trans
-&trans            &trans     &trans            &trans     &trans            &trans  &trans  &trans    &trans    &trans    &mo 3
-&trans            &kp LG(X)  &kp LG(C)         &kp LG(V)  &trans  &trans    &trans  &trans  &mkp MB1  &mkp MB2  &mkp MB3  &mo 3
-&kp LEFT_CONTROL  &trans     &kp LEFT_COMMAND  &trans     &trans  &trans    &trans  &trans                                &trans
+&none             &none      &none             &none      &none                  &none  &none     &none     &none     &none
+&none             &none      &none             &none      &none           &none  &none  &none     &none     &none     &none
+&none             &kp LG(X)  &kp LG(C)         &kp LG(V)  &none  &none    &none  &none  &mkp MB1  &mkp MB2  &mkp MB3  &mo 3
+&kp LEFT_CONTROL  &none      &kp LEFT_COMMAND  &none      &none  &none    &none  &none                                &none
             >;
 
             sensor-bindings = <&scroll_up_down>;
@@ -328,10 +328,10 @@
 
         cursor {
             bindings = <
-&trans     &trans  &trans            &trans  &trans                    &kp LG(UP)    &kp LG(LEFT)    &kp UP_ARROW    &kp LG(RIGHT)    &trans
-&trans     &trans  &trans            &trans  &trans            &trans  &kp LG(DOWN)  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans
-&trans     &trans  &trans            &trans  &trans  &trans    &trans  &trans        &trans          &trans          &trans           &trans
-&kp LCTRL  &trans  &kp LEFT_COMMAND  &trans  &trans  &trans    &trans  &trans                                                         &trans
+&trans     &trans  &trans            &trans  &trans                    &kp PAGE_UP    &trans          &kp UP_ARROW    &trans           &kp HOME
+&trans     &trans  &trans            &trans  &trans            &trans  &kp PAGE_DOWN  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &kp END
+&trans     &trans  &trans            &trans  &trans  &trans    &trans  &trans         &trans          &trans          &trans           &trans
+&kp LCTRL  &trans  &kp LEFT_COMMAND  &trans  &trans  &trans    &trans  &trans                                                          &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/west.yml
+++ b/config/west.yml
@@ -19,15 +19,18 @@ manifest:
       import: app/west.yml
     - name: zmk-pmw3610-driver
       remote: badjeff
-      revision: main
+      # Pinned to zmk-0.3 branch HEAD for ZMK v0.3.0 compatibility
+      revision: 77635bad95097e2ed6fc16624622cff025a0e33b
     # - name: zmk-driver-paw3222
     #   remote: sekigon-gonnoc
     #   revision: main
     - name: zmk-rgbled-widget
       remote: caksoylar
-      revision: main
+      # Pinned before Zephyr 4.1 / XIAO BLE overlay changes (2025-12-10) to avoid incompatibility
+      revision: fbe6dde8ffa68fdcded1600a66aa18cf12a796fb
     - name: zmk-input-processor-keybind
       remote: zettaface
-      revision: main
+      # Pinned to main HEAD for reproducible builds
+      revision: 64303bd3932bfa7f49261fc6d0c9a3fdd06f8271
   self:
     path: config


### PR DESCRIPTION
## 背景
- ZMK 本体は v0.3.0 固定だが、外部モジュールが revision: main 追従のため上流更新で CI が不安定だった。
- ビルド再現性を確保するため、外部モジュールをフルSHAでピン留め。

## 変更内容
- `config/west.yml`
  - zmk-pmw3610-driver: revision → 77635bad95097e2ed6fc16624622cff025a0e33b（zmk-0.3 ブランチ HEAD）
  - zmk-rgbled-widget: revision → fbe6dde8ffa68fdcded1600a66aa18cf12a796fb（2025-12-10 Zephyr 4.1 / XIAO BLE overlay 追加前）
  - zmk-input-processor-keybind: revision → 64303bd3932bfa7f49261fc6d0c9a3fdd06f8271（main HEAD）

## 目的
- 上流 main の予期せぬ変更で CI が壊れないようにする
- 同一リビルドで同一成果物を得られるようにする（再現性確保）

## 確認項目
- [ ] west 同期が通ること（`west update`）
- [ ] GitHub Actions ビルドが成功すること
